### PR TITLE
Implement Purple Ghost: Circling

### DIFF
--- a/src/ghost.rs
+++ b/src/ghost.rs
@@ -63,12 +63,13 @@ impl CirclePursuitData {
     }
 
     pub fn update_transform(&self, pt: &Vec3, gt: &mut Vec3) {
-        // get radius in a sinusoidal pattern
+        // get radius using given function
         let radius = self.base_radius + (
             (self.rad_angle_func)(self.angle*self.angle_rad_mod) * 
             self.radius_delta
         );
 
+        // update position using given x and y funcs and computer radius
         gt.x = pt.x + (self.x_angle_func)(self.angle) * radius;
         gt.y = pt.y + (self.y_angle_func)(self.angle) * radius;
     }


### PR DESCRIPTION
# Overview

Updates ghost component `AttackBehaviorType` to include `CirclePursuit`.
Ghosts with `CirclePursuit` circle the player using a given circling behavior.
Circling behavior is defined using three functions that take in the current angle
&nbsp; &nbsp; and return a new value based on that angle.
`x_angle_func` is used to define the displaced x translation value.
`y_angle_func` is used to define the displaced y translation value.
`rad_angle_func` is used to define the scale factor for the x and y values.
- The "base" value for each of these to just have normal circling behavior is 
`x_angle_func = f32::cos`, `y_angle_func = f32::sin`, and `rad_angle_func = f`
where f is a function that just returns `0.0`.
- setting `rad_angle_func` to `f32::sin` or `f32::cos` will introduce a wave like motion around the player.
This is also what the program is currently set to do. (`rad_angle_func = f32::sin`)

Comments and suggestions are appreciated!

Noah Hendrickson
